### PR TITLE
Feature -  abstract the certificate store

### DIFF
--- a/CSharpSoapToolkit/CSharpSoapToolkit/CSharpSoapToolkit.csproj
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/CSharpSoapToolkit.csproj
@@ -59,11 +59,13 @@
       <DependentUpon>Reference.svcmap</DependentUpon>
     </Compile>
     <Compile Include="InspectorBehavior.cs" />
+    <Compile Include="ISecureCertificateStore.cs" />
     <Compile Include="PropertiesUtility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sample.cs" />
     <Compile Include="SecurityUtility.cs" />
     <Compile Include="SoapEnvelopeUtility.cs" />
+    <Compile Include="ToolkitCertificateStore.cs" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />

--- a/CSharpSoapToolkit/CSharpSoapToolkit/ISecureCertificateStore.cs
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/ISecureCertificateStore.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSharpSoapToolkit
+{
+    /// <summary>
+    /// Ensure any custom implentations are secure
+    /// </summary>
+    public interface ISecureCertificateStore
+    {
+        X509Certificate2 MerchantCertificate { get; }
+    }
+}

--- a/CSharpSoapToolkit/CSharpSoapToolkit/InspectorBehavior.cs
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/InspectorBehavior.cs
@@ -7,9 +7,12 @@ namespace CSharpSoapToolkit
 {
     public class InspectorBehavior : IEndpointBehavior
     {
-        public InspectorBehavior()
+        private ISecureCertificateStore _secureCertificateStore;
+
+        public InspectorBehavior(ISecureCertificateStore secureCertificateStore)
         {
             // not calling the base implementation
+            _secureCertificateStore = secureCertificateStore;
         }
 
         public void Validate(ServiceEndpoint endpoint)
@@ -29,16 +32,18 @@ namespace CSharpSoapToolkit
 
         public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
         {
-            clientRuntime.ClientMessageInspectors.Add(new ClientInspector());
+            clientRuntime.ClientMessageInspectors.Add(new ClientInspector(_secureCertificateStore));
         }
     }
 
     public class ClientInspector : IClientMessageInspector
     {
         public MessageHeader[] Headers { get; set; }
+        private ISecureCertificateStore _secureCertificateStore;
 
-        public ClientInspector(params MessageHeader[] headers)
+        public ClientInspector(ISecureCertificateStore secureCertificateStore, params MessageHeader[] headers)
         {
+            _secureCertificateStore = secureCertificateStore;
             Headers = headers;
         }
 
@@ -53,7 +58,7 @@ namespace CSharpSoapToolkit
                     request.Headers.Insert(0, Headers[i]);
             }
 
-            SoapEnvelopeUtility.AddSecurityElements(ref copy);
+            SoapEnvelopeUtility.AddSecurityElements(ref copy, _secureCertificateStore);
 
             request = copy;
 

--- a/CSharpSoapToolkit/CSharpSoapToolkit/Sample.cs
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/Sample.cs
@@ -68,7 +68,7 @@ namespace CSharpSoapToolkit
             {
                 TransactionProcessorClient proc = new TransactionProcessorClient();
 
-                proc.Endpoint.EndpointBehaviors.Add(new InspectorBehavior());
+                proc.Endpoint.EndpointBehaviors.Add(new InspectorBehavior(new ToolkitCertificateStore())); //or your owm ISecureCertificateStore
 
                 ReplyMessage reply = proc.runTransaction(request);
 

--- a/CSharpSoapToolkit/CSharpSoapToolkit/SecurityUtility.cs
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/SecurityUtility.cs
@@ -10,33 +10,35 @@ namespace CSharpSoapToolkit
 {
     public class SecurityUtility
     {
-        private static readonly IDictionary<string, string> _userDefinedProperties;
+        //private static readonly IDictionary<string, string> _userDefinedProperties;
 
-        static SecurityUtility()
-        {
-            // Load Properties
-            try
-            {
-                _userDefinedProperties = PropertiesUtility.LoadProperties();
-            }
-            catch (IOException e)
-            {
-                throw new Exception(e.Message);
-            }
-        }
+        //static SecurityUtility()
+        //{
+        //    // Load Properties
+        //    try
+        //    {
+        //        _userDefinedProperties = PropertiesUtility.LoadProperties();
+        //    }
+        //    catch (IOException e)
+        //    {
+        //        throw new Exception(e.Message);
+        //    }
+        //}
 
-        public static string GenerateBinarySecurityToken()
+        public static string GenerateBinarySecurityToken(ISecureCertificateStore secureCertificateStore)
         {
-            var certificate = ExtractMerchantCertificateFromFile();
+            //var certificate = ExtractMerchantCertificateFromFile();
+            var certificate = secureCertificateStore.MerchantCertificate;
+
             var certificateBytes = certificate.GetRawCertData();
             return Convert.ToBase64String(certificateBytes);
         }
 
-        private static X509Certificate2 ExtractMerchantCertificateFromFile()
-        {
-            // (i) Get certificate
-            return CertificateCacheUtility.FetchCachedCertificate(PropertiesUtility.GetKeyFilePath(), _userDefinedProperties["KEY_PASS"]);
-        }
+        //private static X509Certificate2 ExtractMerchantCertificateFromFile()
+        //{
+        //    // (i) Get certificate
+        //    return CertificateCacheUtility.FetchCachedCertificate(PropertiesUtility.GetKeyFilePath(), _userDefinedProperties["KEY_PASS"]);
+        //}
 
         public static void CreateDetachedSignature(ref XmlDocument xmlDoc, RSA privateKey, XmlElement securityTokenReference)
         {
@@ -126,9 +128,10 @@ namespace CSharpSoapToolkit
             }
         }
 
-        public static RSA GetKeyFromCertificate()
+        public static RSA GetKeyFromCertificate(ISecureCertificateStore secureCertificateStore)
         {
-            var certificate = CertificateCacheUtility.FetchCachedCertificate(PropertiesUtility.GetKeyFilePath(), _userDefinedProperties["KEY_PASS"]);
+            //var certificate = CertificateCacheUtility.FetchCachedCertificate(PropertiesUtility.GetKeyFilePath(), _userDefinedProperties["KEY_PASS"]);
+            var certificate = secureCertificateStore.MerchantCertificate;
 
             // Get the private key
             var privateKey = certificate.GetRSAPrivateKey();

--- a/CSharpSoapToolkit/CSharpSoapToolkit/SoapEnvelopeUtility.cs
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/SoapEnvelopeUtility.cs
@@ -6,7 +6,7 @@ namespace CSharpSoapToolkit
 {
     public class SoapEnvelopeUtility
     {
-        public static void AddSecurityElements(ref Message request)
+        public static void AddSecurityElements(ref Message request, ISecureCertificateStore secureCertificateStore)
         {
             // (i) Import Request into XmlDocument
             XmlDocument xmlDoc = new XmlDocument { PreserveWhitespace = true };
@@ -52,7 +52,7 @@ namespace CSharpSoapToolkit
             XmlAttribute tokenElementAttribute = xmlDoc.CreateAttribute("wsu", "Id", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
             tokenElementAttribute.Value = "X509Token";
             tokenElement.Attributes.Append(tokenElementAttribute);
-            tokenElement.InnerXml = SecurityUtility.GenerateBinarySecurityToken();
+            tokenElement.InnerXml = SecurityUtility.GenerateBinarySecurityToken(secureCertificateStore);
 
             // (v) Add Security envelope
             XmlElement securityElement = xmlDoc.CreateElement("wsse", "Security", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
@@ -67,7 +67,7 @@ namespace CSharpSoapToolkit
             securityTokenReferenceElement.AppendChild(referenceElement);
 
             // (vii) Combine Binary Security Token with Signature
-            SecurityUtility.CreateDetachedSignature(ref xmlDoc, SecurityUtility.GetKeyFromCertificate(), securityTokenReferenceElement);
+            SecurityUtility.CreateDetachedSignature(ref xmlDoc, SecurityUtility.GetKeyFromCertificate(secureCertificateStore), securityTokenReferenceElement);
 
             // (viii) Export back to Request object
             var memoryStream = new MemoryStream(); // This has to remain open. Do NOT use `using` statement.

--- a/CSharpSoapToolkit/CSharpSoapToolkit/ToolkitCertificateStore.cs
+++ b/CSharpSoapToolkit/CSharpSoapToolkit/ToolkitCertificateStore.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSharpSoapToolkit
+{
+    /// <summary>
+    /// Makes use of PropertiesUtility, CertificateCacheUtility and the Portable.BouncyCastle dependancy
+    /// if you choose not to use ToolkitCertificateStore, then the above are optional
+    /// </summary>
+    public class ToolkitCertificateStore : ISecureCertificateStore
+    {
+        private static readonly IDictionary<string, string> _userDefinedProperties;
+
+        static ToolkitCertificateStore()
+        {
+            // Load Properties
+            try
+            {
+                _userDefinedProperties = PropertiesUtility.LoadProperties();
+            }
+            catch (IOException e)
+            {
+                throw new Exception(e.Message);
+            }
+        }
+
+        public  X509Certificate2 MerchantCertificate { 
+            get 
+            {
+                return ExtractMerchantCertificateFromFile();
+            } 
+        }
+
+        private static X509Certificate2 ExtractMerchantCertificateFromFile()
+        {
+            // (i) Get certificate
+            return CertificateCacheUtility.FetchCachedCertificate(PropertiesUtility.GetKeyFilePath(), _userDefinedProperties["KEY_PASS"]);
+        }
+    }
+}

--- a/CSharpSoapToolkit/README.md
+++ b/CSharpSoapToolkit/README.md
@@ -31,6 +31,9 @@ You must create a P12 certificate. See the [REST Getting Started Developer Guide
 With this change to use a P12 certificate in your C# SOAP toolkit configuration, the new requirements for your application will be:
 
 - .NET Framework 4.7.2 and later Redistributable Package
+
+If using the ToolkitCertificateStore utility then these are the additional requirements for your application:
+
 - [NuGet Command-Line Interface](https://learn.microsoft.com/en-us/nuget/reference/nuget-exe-cli-reference?tabs=windows)
 - Portable.BouncyCastle
 
@@ -52,7 +55,7 @@ Follow these steps to upgrade your existing C# code:
 
 ### Modifying `app.config`
 
-1. Add the following sections to the top of your `app.config` file:
+1. Add the following sections to the top of your `app.config` file (If using the ToolkitCertificateStore utility):
 
    ```xml
    <configuration>
@@ -86,7 +89,7 @@ Follow these steps to upgrade your existing C# code:
    </bindings>
    ```
 
-### Adding new dependency
+### Adding new dependency (If using the ToolkitCertificateStore utility)
 
 1. Add this dependency to the `packages.config` file:
 
@@ -112,16 +115,23 @@ Follow these steps to upgrade your existing C# code:
 
 ### Adding new files to project
 
-1. Add your P12 certificate to the `KEY_DIRECTORY`.
+1. Add your P12 certificate to the `KEY_DIRECTORY`(If using the ToolkitCertificateStore utility).
 
    This `KEY_DIRECTORY` location must be accessible by your code. Ensure that your code has permissions to read this location.
 
 2. Copy these files to your project directory:
-   - [CertificateCacheUtility.cs](CSharpSoapToolkit\CertificateCacheUtility.cs)
    - [InspectorBehavior.cs](CSharpSoapToolkit\InspectorBehavior.cs)
    - [PropertiesUtility.cs](CSharpSoapToolkit\PropertiesUtility.cs)
    - [SecurityUtility.cs](CSharpSoapToolkit\SecurityUtility.cs)
    - [SoapEnvelopeUtility.cs](CSharpSoapToolkit\SoapEnvelopeUtility.cs)
+   - [ISecureCertificateStore.cs](CSharpSoapToolkit\ISecureCertificateStore.cs)
+
+If using the ToolkitCertificateStore utility then copy these addional files:
+   - [ToolkitCertificateStore.cs](CSharpSoapToolkit\ToolkitCertificateStore.cs)
+   - [CertificateCacheUtility.cs](CSharpSoapToolkit\CertificateCacheUtility.cs)
+   - [PropertiesUtility.cs](CSharpSoapToolkit\PropertiesUtility.cs)
+
+If you are not using ToolkitCertificateStore then implement your own secure ISecureCertificateStore
 
 3. Import the files above to your project.
 
@@ -143,7 +153,7 @@ Follow these steps to upgrade your existing C# code:
    ```csharp
    TransactionProcessorClient proc = new TransactionProcessorClient();
 
-   proc.Endpoint.EndpointBehaviors.Add(new InspectorBehavior());
+   proc.Endpoint.EndpointBehaviors.Add(new InspectorBehavior(new ToolkitCertificateStore()));  //or your owm ISecureCertificateStore
 
    ReplyMessage reply = proc.runTransaction(request);
    ```


### PR DESCRIPTION
Allow apps to implement their own secure certificate stores. E.g. cases where they already have similar infrastructure.
Makes the nuget package optional.